### PR TITLE
Update pom to prepare for release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@
 .classpath
 .settings/
 target/
+.vscode/
+
+# A maven-shade-plugin temp artifact
+dependency-reduced-pom.xml

--- a/pass-indexer-checker-app/pom.xml
+++ b/pass-indexer-checker-app/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>pass-indexer-checker</artifactId>
     <groupId>org.eclipse.pass</groupId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pass-indexer-checker-app</artifactId>

--- a/pass-indexer-checker-integration/pom.xml
+++ b/pass-indexer-checker-integration/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>pass-indexer-checker</artifactId>
     <groupId>org.eclipse.pass</groupId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>pass-indexer-checker-integration</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -44,8 +44,8 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>
-    <pass.client.version>0.9.0-SNAPSHOT</pass.client.version>
-    <pass.client.api.version>0.9.0-SNAPSHOT</pass.client.api.version>
+    <pass.client.version>0.1.0-SNAPSHOT</pass.client.version>
+    <pass.client.api.version>0.1.0-SNAPSHOT</pass.client.api.version>
     <pass.model.version>0.9.0-SNAPSHOT</pass.model.version>
     <args4j.version>2.33</args4j.version>
     <slf4j.api.version>1.7.36</slf4j.api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,17 +7,17 @@
   <parent>
     <groupId>org.eclipse.pass</groupId>
     <artifactId>eclipse-pass-parent</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
   </parent>
 
   <groupId>org.eclipse.pass</groupId>
   <artifactId>pass-indexer-checker</artifactId>
   <packaging>pom</packaging>
-  <version>1.0.2-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
 
   <name>PASS indexer Checker</name>
   <description>Utility for verifying the health of the PASS Repository Indexer</description>
-  <url>https://github.com/OA-PASS/pass-indexer-checker</url>
+  <url>https://github.com/eclipse-pass/pass-indexer-checker</url>
 
   <modules>
     <module>pass-indexer-checker-app</module>


### PR DESCRIPTION
* Update version to 0.1.0-SNAPSHOT
* Ignore temporary maven-shade-plugin file
* Update a POM URL to point to eclipse-pass (instead of oa-pass)